### PR TITLE
highlight hovered parts of key and pie chart, organise types

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, FC } from "react";
 import styled from "styled-components";
 
-import { Filter, OutputObject } from "../utils/types";
+import { FilterType, LogType } from "../utils/types";
 import { allLogs } from "../utils/processed-data";
 import Stats from "./stats/Stats";
 import Logbook from "./logbook/Logbook";
@@ -14,6 +14,7 @@ const Root = styled.div`
   font-family: ${fonts.main};
   font-size: ${fontSize.small};
   line-height: 1.4;
+  min-height: 100vh;
 `;
 
 const Header = styled.header`
@@ -61,26 +62,20 @@ const DailyMessage = styled.p`
 const ViewContainer = styled.div`
   max-width: 60rem;
   margin: 0 auto;
-  padding: 1rem 0;
+  padding-top: 1rem;
+  box-sizing: border-box;
   overflow: hidden;
 `;
 
-const ViewPanel = styled.div<{ readonly isLogbook: boolean }>`
+const ViewPanel = styled.div<{ translatePercent: number }>`
   display: flex;
   width: 200%;
-  ${({ isLogbook }) =>
-    isLogbook
-      ? `
-    transform: translateX(-50%);
-    transition: transform ease-in-out 1s;
-  `
-      : `
-    transform: translateX(0%);
-    transition: transform ease-in-out 1s;
-  `}
+  height: 100%;
+  transition: transform ease-in-out 1s;
+  transform: translateX(${props => props.translatePercent}%);
 `;
 
-interface Views {
+type Views = {
   s: string;
   l: string;
 }
@@ -91,10 +86,10 @@ const views: Views = {
 
 const App: FC = (): JSX.Element => {
   const [activeView, setActiveView] = useState<string>(views.s);
-  const [logs, setLogs] = useState<OutputObject[]>(allLogs);
+  const [logs, setLogs] = useState<LogType[]>(allLogs);
   const [message, setMessage] = useState<string | null>(null);
 
-  const handleSingleDay = (logs: OutputObject[], filter: Filter): void => {
+  const handleSingleDay = (logs: LogType[], filter: FilterType): void => {
     const { day, month, year } = filter;
     setActiveView(views.l);
     setLogs(logs);
@@ -128,9 +123,9 @@ const App: FC = (): JSX.Element => {
       </Header>
 
       <ViewContainer>
-        <ViewPanel isLogbook={activeView === views.l}>
+        <ViewPanel translatePercent={activeView === views.l ? -50 : 0}>
           <Stats logs={logs} handleSingleDay={handleSingleDay} />
-          <Logbook logs={logs} />
+          <Logbook logs={logs} isActive={activeView === views.l}/>
         </ViewPanel>
       </ViewContainer>
     </Root>

--- a/src/components/common/icons/iconFunc.tsx
+++ b/src/components/common/icons/iconFunc.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { IconOptions } from "../../../utils/types";
+import { LogbookIconsType } from "../../../utils/types";
 
 import Chevron from "./Chevron";
 import Comment from "./Comment";
@@ -11,10 +11,10 @@ import Partner from "./Partner";
 import Style from "./Style";
 
 type Icons = {
-  [key in IconOptions]: JSX.Element;
+  [key in LogbookIconsType]: JSX.Element;
 }
 
-const iconFunc = (item: IconOptions, props?: object): JSX.Element => {
+const iconFunc = (item: LogbookIconsType, props?: object): JSX.Element => {
   const icons: Icons = {
     chevron: <Chevron {...props} />,
     comment: <Comment {...props} />,

--- a/src/components/common/useIsWidth.tsx
+++ b/src/components/common/useIsWidth.tsx
@@ -5,10 +5,10 @@ import { breakpoint } from "./styleVariables";
 
 import { Breakpoints } from "../../utils/types";
 
-interface OutputWidth {
+type WidthType = {
   isWidth: boolean
 }
-const useIsWidth = (width: Breakpoints): OutputWidth => {
+const useIsWidth = (width: Breakpoints): WidthType => {
   const check = matchMedia(`(min-width: ${breakpoint[width]})`);
   const [state, setState] = useState<MediaQueryList | boolean>(check);
 

--- a/src/components/logbook/Logbook.tsx
+++ b/src/components/logbook/Logbook.tsx
@@ -1,7 +1,7 @@
 import React, { useState, Fragment, FC } from "react";
 import styled from "styled-components";
 
-import { OutputObject, DefaultSearch } from "../../utils/types";
+import { LogType, SearchType } from "../../utils/types";
 
 import Search from "./Search";
 import SearchReset from "./SearchReset";
@@ -9,26 +9,28 @@ import PageNav from "./PageNav";
 import Results from "./Results";
 import SingleLog from "../singleLog/SingleLog";
 
-const LogContainer = styled.div`
+const LogContainer = styled.div<{isActive: boolean}>`
   width: 50%;
+  ${({ isActive }) => !isActive && `height: 0`};
 `;
 
-const defaultSearch: DefaultSearch = {
+const defaultSearch: SearchType = {
   placeholder: "Search by Climb or Crag name...",
   searchTerm: "",
   results: undefined,
 };
 
-interface Props {
-  logs: OutputObject[];
+type Props = {
+  isActive: boolean;
+  logs: LogType[];
 }
-const Logbook: FC<Props> = ({ logs }) => {
-  const [search, setSearch] = useState<DefaultSearch | undefined>(defaultSearch);
+const Logbook: FC<Props> = ({ isActive, logs }): JSX.Element => {
+  const [search, setSearch] = useState<SearchType | undefined>(defaultSearch);
   const [page, setPage] = useState<{ low: number; high: number }>({ low: 0, high: 50 });
-  const [singleLog, setSingleLog] = useState<OutputObject | undefined>(undefined);
+  const [singleLog, setSingleLog] = useState<LogType | undefined>(undefined);
 
-  const handleSearch = (value: string): DefaultSearch | void => {
-    const findResults = (value: string, logs: OutputObject[]): OutputObject[] | void => {
+  const handleSearch = (value: string): SearchType | void => {
+    const findResults = (value: string, logs: LogType[]): LogType[] | void => {
       if (value.length < 3) return;
       return logs.filter(log => {
         const regex = new RegExp(value, "gi");
@@ -51,13 +53,13 @@ const Logbook: FC<Props> = ({ logs }) => {
     }
   };
 
-  // TODO: stricter checking here. Should be ascent-<number>, see OutputObject
+  // TODO: stricter checking here. Should be ascent-<number>, see LogType
   const handleSingleView = (index: string | null): void => {
     return setSingleLog(logs.find(i => i.key === index));
   };
 
   return (
-    <LogContainer>
+    <LogContainer isActive={isActive}>
       <div>
         {!singleLog && (
           <Fragment>

--- a/src/components/logbook/PageNav.tsx
+++ b/src/components/logbook/PageNav.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import styled, { css } from "styled-components";
 
-import { OutputObject } from "../../utils/types";
+import { LogType } from "../../utils/types";
 
 import useIsWidth from "../common/useIsWidth";
 import Chevron from "../common/icons/Chevron";
@@ -92,7 +92,7 @@ interface Buttons {
 }
 
 interface Props {
-  logs: OutputObject[];
+  logs: LogType[];
   low: number;
   high: number;
   handlePageChange: (direction: string) => void;

--- a/src/components/logbook/Results.tsx
+++ b/src/components/logbook/Results.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import styled from "styled-components";
 
-import { OutputObject } from "../../utils/types";
+import { LogType } from "../../utils/types";
 
 import useIsWidth from "../common/useIsWidth";
 import Chevron from "../common/icons/Chevron";
@@ -84,7 +84,7 @@ const Date = styled.span`
 `;
 
 interface Props {
-  logs: OutputObject[];
+  logs: LogType[];
   low: number;
   high: number;
   handleSingleView: (index: string | null) => void;

--- a/src/components/logbook/Search.tsx
+++ b/src/components/logbook/Search.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import styled from "styled-components";
 
-import { DefaultSearch } from "../../utils/types";
+import { SearchType } from "../../utils/types";
 
 import useIsWidth from "../common/useIsWidth";
 import { searchResultText } from "../common/Typography";
@@ -128,7 +128,7 @@ const Date = styled.span`
   font-weight: 600;
 `;
 
-type Props = Partial<DefaultSearch> & {
+type Props = Partial<SearchType> & {
   handleSearch: (value: string) => void;
   handleSingleView: (index: string | null) => void;
 };

--- a/src/components/singleLog/SingleLog.tsx
+++ b/src/components/singleLog/SingleLog.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import styled from "styled-components";
 
-import { OutputObject, LogOptions } from "../../utils/types";
+import { LogType, LogbookType } from "../../utils/types";
 
 import { colors, breakpoint } from "../common/styleVariables";
 import { buttonBase } from "../common/Buttons";
@@ -136,7 +136,7 @@ const ButtonContainer = styled.div`
   }
 `;
 
-const getText = (item: keyof OutputObject, props: Props) => {
+const getText = (item: keyof LogType, props: Props) => {
   if (item === "date") {
     const {
       processed: { dayLong, monthLong, year },
@@ -150,13 +150,13 @@ const getText = (item: keyof OutputObject, props: Props) => {
   }
 };
 
-interface Props extends OutputObject {
+interface Props extends LogType {
   handleSingleView: (index: string | null) => void;
 }
 const SingleLog: FC<Props> = props => {
   const { climbName, handleSingleView, notes } = props;
 
-  const logDetails: Array<LogOptions> = ["grade", "cragName", "style", "date", "partners"];
+  const logDetails: Array<LogbookType> = ["grade", "cragName", "style", "date", "partners"];
 
   return (
     <Container>

--- a/src/components/stats/PieArc.tsx
+++ b/src/components/stats/PieArc.tsx
@@ -1,0 +1,57 @@
+import React, { FC } from "react";
+import styled from "styled-components";
+
+import { ChartType } from "../../utils/types";
+
+const ArcGroup = styled.g<{ opacity: number }>`
+  cursor: pointer;
+  transition: opacity ease-in-out 0.3;
+  opacity: ${({ opacity }) => opacity};
+`;
+
+const Text = styled.text`
+  cursor: none;
+  user-select: none;
+  pointer-events: none;
+  font-size: 0.625rem;
+  fill: white;
+  text-anchor: middle;
+`;
+
+type Props = {
+  activeArcIndex: number | undefined;
+  data: ChartType;
+  index: number;
+  onClick: () => void;
+  setTooltip: (index: number | undefined) => void;
+};
+
+const PieArc: FC<Props> = ({
+  activeArcIndex,
+  colors,
+  createArc,
+  data,
+  format,
+  index,
+  onClick,
+  setTooltip,
+}) => {
+  const hovered = Boolean(activeArcIndex || activeArcIndex === 0);
+  return (
+    <ArcGroup
+      key={index}
+      opacity={hovered && activeArcIndex !== index ? 0.65 : 1}
+      onClick={onClick}
+    >
+      <path
+        d={createArc(data)}
+        fill={colors(index)}
+        onMouseOver={() => setTooltip(index)}
+        onMouseOut={() => setTooltip(undefined)}
+      />
+      <Text transform={`translate(${createArc.centroid(data)})`}>{format(data.value)}</Text>
+    </ArcGroup>
+  );
+};
+
+export default PieArc;

--- a/src/components/stats/StatsContext.tsx
+++ b/src/components/stats/StatsContext.tsx
@@ -1,0 +1,42 @@
+import React, { FC, createContext, useReducer } from "react";
+
+interface ContextProps {
+  state: any;
+  dispatch: ({ type }: { type: string }) => void;
+}
+let StatsContext = createContext<{}>({} as ContextProps);
+
+type InitialStateType = {
+  activeArcIndex: undefined | number;
+};
+let initialState: InitialStateType = {
+  activeArcIndex: undefined,
+};
+
+type ActionType = {
+  payload: undefined | number;
+  type: string;
+};
+
+let reducer = (state: InitialStateType, action: ActionType) => {
+  switch (action.type) {
+    case "activeArcIndex":
+      return { ...state, activeArcIndex: action.payload };
+    default:
+      console.error("Context Error: No cases found:", action.type);
+      return { ...state };
+  }
+};
+
+type Props = {
+  init?: InitialStateType;
+};
+const StatsContextProvider: FC<Props> = ({ init = initialState, children }) => {
+  const [state, dispatch] = useReducer(reducer, init);
+  const value = { state, dispatch };
+  return <StatsContext.Provider value={value}>{children}</StatsContext.Provider>;
+};
+
+const StatsContextConsumer = StatsContext.Consumer;
+
+export { StatsContext, StatsContextProvider, StatsContextConsumer };

--- a/src/components/stats/StatsHeader.tsx
+++ b/src/components/stats/StatsHeader.tsx
@@ -2,7 +2,7 @@ import React, { FC } from "react";
 import styled from "styled-components";
 import Select, { StylesConfig, ValueType } from "react-select";
 
-import { Category, DefaultSettings, OutputObject } from "../../utils/types";
+import { CategoryInt, SettingsInt, SettingsType, LogType } from "../../utils/types";
 import { breakpoint, colors } from "../common/styleVariables";
 
 const Header = styled.header`
@@ -30,19 +30,18 @@ const CategoriesControl = styled.div`
   border-left: 1px solid ${colors.black};
   padding-left: 1rem;
   margin-left: 1rem;
-  label {
-    margin-right: 1rem;
-  }
-`;
-
-const FilterLabel = styled.label`
-  margin-right: 2rem;
-  strong {
-    font-weight: 700;
-  }
   font-size: 1rem;
   @media only screen and (min-width: ${breakpoint.Xsmall}) {
     font-size: 1.25rem;
+  }
+`;
+
+const Label = styled.label`
+  font-size: 1rem;
+  margin-right: 0.75rem;
+  @media only screen and (min-width: ${breakpoint.Xsmall}) {
+    font-size: 1.25rem;
+    margin-right: 1rem;
   }
 `;
 
@@ -51,6 +50,10 @@ const FilterControl = styled.div`
   align-items: center;
   width: 100%;
   margin: 1rem 0;
+  font-size: 1rem;
+  @media only screen and (min-width: ${breakpoint.Xsmall}) {
+    font-size: 1.25rem;
+  }
 `;
 
 const Controls = styled.div`
@@ -59,12 +62,12 @@ const Controls = styled.div`
 
 const customStyles: StylesConfig = {
   control: (provided, state) => {
-    const { isFocused } = state;
+    const { isFocused, selectProps: { width } } = state;
     const color = colors[isFocused ? "red" : "midGrey"];
     const backgroundColor = colors[isFocused ? "lightRed" : "white"];
     return {
       ...provided,
-      width: 140,
+      width: width || 140,
       backgroundColor,
       borderColor: color,
       boxShadow: `0 0 1px ${color}`,
@@ -73,7 +76,7 @@ const customStyles: StylesConfig = {
     };
   },
   indicatorSeparator: () => ({
-    borderColor: colors.midGrey
+    borderColor: colors.midGrey,
   }),
   option: (provided, state) => ({
     ...provided,
@@ -97,14 +100,14 @@ const categories = [
 ];
 
 const dates = [
-  { value: "year", label: "Year" },
-  { value: "month", label: "Month" },
+  { value: "year", label: "All Years" },
+  { value: "month", label: "Combined Months" },
 ];
 
 type Props = {
-  logs: OutputObject[];
-  type: keyof DefaultSettings;
-  setDropdown: (type: keyof DefaultSettings, item: ValueType<Category>) => void;
+  logs: LogType[];
+  type: SettingsType;
+  setDropdown: (type: keyof SettingsInt, item: ValueType<CategoryInt>) => void;
 };
 const StatsHeader: FC<Props> = ({ logs, setDropdown, type }): JSX.Element => (
   <Header>
@@ -113,7 +116,7 @@ const StatsHeader: FC<Props> = ({ logs, setDropdown, type }): JSX.Element => (
         Total Logs: <strong>{logs.length}</strong>
       </H1>
       <CategoriesControl>
-        <label htmlFor="categories-control">Stats by:</label>
+        <Label htmlFor="categories-control">Stats by:</Label>
         <Select
           aria-label="Select by Category"
           defaultValue={categories[0]}
@@ -125,14 +128,11 @@ const StatsHeader: FC<Props> = ({ logs, setDropdown, type }): JSX.Element => (
           placeholder="Select by Category"
           styles={customStyles}
           value={categories.find(i => i.value === type)}
-          width="200px"
         />
       </CategoriesControl>
     </Categories>
     <FilterControl>
-      <FilterLabel htmlFor={`${type}-control`}>
-        Filter <strong>{type}</strong>
-      </FilterLabel>
+      <Label htmlFor={`${type}-control`}>Filtering by:</Label>
       <Controls>
         <Select
           aria-label={`Select by ${type}`}
@@ -145,7 +145,7 @@ const StatsHeader: FC<Props> = ({ logs, setDropdown, type }): JSX.Element => (
           placeholder={`Select by ${type}`}
           styles={customStyles}
           value={dates.find(i => i.value === type)}
-          width="200px"
+          width={220}
         />
       </Controls>
     </FilterControl>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,7 +1,7 @@
-import { DefaultSettings, MonthOptions, Grades } from "./types";
+import { GradeTypes, MonthType, SettingsInt } from "./types";
 import { colors } from "../components/common/styleVariables";
 
-const defaultSettings: DefaultSettings = {
+const defaultSettings: SettingsInt = {
   date: { cumulative: "Year" },
   discipline: { cumulative: "Trad" },
   grade: { cumulative: "Low" },
@@ -11,7 +11,7 @@ const defaultSettings: DefaultSettings = {
 };
 
 type IntOptions = "01" | "02" | "03" | "04" | "05" | "06" | "07" | "08" | "09" | "10" | "11" | "12";
-type MonthOptionsLong =
+type MonthTypeLong =
   | "January"
   | "February"
   | "March"
@@ -26,10 +26,10 @@ type MonthOptionsLong =
   | "December";
 
 interface Month {
-  text: MonthOptionsLong;
+  text: MonthTypeLong;
   int: IntOptions;
 }
-type Months = { [month in MonthOptions]: Month };
+type Months = { [month in MonthType]: Month };
 const months: Months = {
   Jan: { text: "January", int: "01" },
   Feb: { text: "February", int: "02" },
@@ -45,7 +45,7 @@ const months: Months = {
   Dec: { text: "December", int: "12" },
 };
 
-const grades: Grades = {
+const grades: GradeTypes = {
   Grade: {
     difficulty: "not set",
     band: `${colors.darkGrey}`,

--- a/src/utils/get-date.ts
+++ b/src/utils/get-date.ts
@@ -1,6 +1,6 @@
-import { DateOptions } from "./types";
+import { DateType } from "./types";
 
-const getDate = (dateData: DateOptions, desktop: boolean): string => {
+const getDate = (dateData: DateType, desktop: boolean): string => {
   const { day, dayLong, monthInt, monthLong, year, yearInt } = dateData;
   if (desktop) {
     return `${dayLong} ${monthLong} ${year}`;

--- a/src/utils/get-gradebands.ts
+++ b/src/utils/get-gradebands.ts
@@ -1,11 +1,11 @@
-import { Grade, Grades } from './types';
+import { GradeType, GradeTypes } from './types';
 import { grades } from './constants'
 
 interface GradeOutput {
-  [key: string]: Grade;
+  [key: string]: GradeType;
 }
 
-const getGrades = (obj: Grades): GradeOutput => {
+const getGrades = (obj: GradeTypes): GradeOutput => {
   const newObj: GradeOutput = {};
   Object.entries(obj).forEach(([key, value]) => {
     const subkeys = key.split(/,\s?/);

--- a/src/utils/process-date.ts
+++ b/src/utils/process-date.ts
@@ -1,6 +1,6 @@
 
 
-import { MonthOptions, DateOptions } from "./types";
+import { MonthType, DateType } from "./types";
 import { months } from "./constants";
 
 type MonthYearInputOptions = "day" | "month" | "monthLong" | "year"
@@ -56,8 +56,8 @@ const processDaySuffix = (day: string): string => {
   return `${num}th`;
 };
 
-export const processDate = (date: string): DateOptions => {
-  const defaultRes: DateOptions = {
+export const processDate = (date: string): DateType => {
+  const defaultRes: DateType = {
     year: "unknown",
     month: "unknown",
     monthLong: "unknown",
@@ -71,14 +71,14 @@ export const processDate = (date: string): DateOptions => {
 
   // month and year only
   if (dateArr.length === 2) {
-    const [month, year] = <[m: MonthOptions, y: string]>dateArr;
+    const [month, year] = <[m: MonthType, y: string]>dateArr;
     const newRes = { ...defaultRes };
     return processMonthYear(month, year, newRes);
   }
 
   // day, month, and year
   if (dateArr.length === 3) {
-    const [day, month, year] = <[d: string, m: MonthOptions, y: string]>dateArr;
+    const [day, month, year] = <[d: string, m: MonthType, y: string]>dateArr;
     const newRes = { ...defaultRes };
     if (day && !day.includes("?") && day.length === 2) {
       newRes.day = day;

--- a/src/utils/processed-data.ts
+++ b/src/utils/processed-data.ts
@@ -1,20 +1,10 @@
-import { OutputObject } from "./types";
+import { InputLogType, LogType } from "./types";
 
 import sourceData from "../data/mb-logbook.json";
 import { processDate } from "./process-date";
 
-interface InputObject {
-  "Climb name": string;
-  "Crag name": string;
-  "Date": string;
-  "Grade": string;
-  "Notes"?: string;
-  "Partner(s)"?: string;
-  "Style": string;
-}
-
-const formatData = (rawData: InputObject[]): OutputObject[] => {
-  const ret: OutputObject[] = [];
+const formatData = (rawData: InputLogType []): LogType[] => {
+  const ret: LogType[] = [];
   rawData.forEach((item, index: number) => {
     ret.push({
       climbName: item["Climb name"],

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,6 +1,84 @@
 import { OptionTypeBase } from "react-select";
-// Notes is optional on this
-type MonthOptions =
+
+export type Breakpoints =
+  | "XXsmall"
+  | "Xsmall"
+  | "small"
+  | "tablet"
+  | "large"
+  | "Xlarge"
+  | "massive";
+
+export interface CategoryInt extends OptionTypeBase {
+  value: string;
+  label: string;
+}
+
+type ChartTypeData = {
+  itemFilter: string;
+  keyLabel: string[];
+  tooltipLabel: string;
+  value: number;
+};
+
+export type ChartType = {
+  data: ChartTypeData;
+  endAngle: number;
+  index: number;
+  padAngle: number;
+  startAngle: number;
+  value: number;
+};
+
+export type DateType = {
+  year: string;
+  yearInt?: string;
+  month: string;
+  monthLong: string;
+  monthInt?: string;
+  day: string;
+  dayLong?: string;
+};
+
+type DefaultDates = "Year" | "Month";
+type DefaultDisciplines = "Bouldering" | "Ice" | "Mixed" | "Sport" | "Trad";
+type DefaultGrades = "Low" | "High"; // order low to high
+type DefaultPartners = string | undefined;
+type DefaultStyles = "Dnf" | "Dogged" | "Flashed" | "Onsight" | "Redpoint";
+
+export type FilterType = {
+  day: string;
+  month: string;
+  year: string;
+};
+
+export type InputLogType = {
+  "Climb name": string;
+  "Crag name": string;
+  Date: string;
+  Grade: string;
+  Notes?: string;
+  "Partner(s)"?: string;
+  Style: string;
+};
+
+type LogDateType = {
+  original: string;
+  processed: DateType;
+};
+
+export type LogType = {
+  climbName: string;
+  cragName: string;
+  date: LogDateType;
+  grade: string;
+  key: string;
+  notes?: string;
+  partners: string;
+  style: string;
+};
+
+export type MonthType =
   | "Jan"
   | "Feb"
   | "Mar"
@@ -14,94 +92,36 @@ type MonthOptions =
   | "Nov"
   | "Dec";
 
-interface DateOptions {
-  year: string;
-  yearInt?: string;
-  month: string;
-  monthLong: string;
-  monthInt?: string;
-  day: string;
-  dayLong: string;
-}
-
-interface Date {
-  original: string;
-  processed: DateOptions;
-}
-
-type DefaultDates = "Year" | "Month";
-type DefaultDisciplines = "Bouldering" | "Ice" | "Mixed" | "Sport" | "Trad";
-type DefaultGrades = "Low" | "High"; // order low to high
-type DefaultPartners = string | undefined;
-type DefaultStyles = "Dnf" | "Dogged" | "Flashed" | "Onsight" | "Redpoint";
-type DefaultCategories = "crag" | "date" | "discipline" | "grade" | "style";
-
-export interface Category extends OptionTypeBase {
-  value: string;
-  label: string;
-}
-
-export interface DefaultSettings {
-  date: { cumulative: DefaultDates };
-  discipline: { cumulative: DefaultDisciplines };
-  grade: { cumulative: DefaultGrades };
-  partners: { cumulative: DefaultPartners };
-  style: { cumulative: DefaultStyles };
-  type: DefaultCategories;
-}
-
-export interface Filter {
-  day: string;
-  month: string;
-  year: string;
-}
-
-interface OutputObject {
-  climbName: string;
-  cragName: string;
-  date: Date;
-  grade: string;
-  key: string;
-  notes?: string;
-  partners: string;
-  style: string;
-}
-
-type DefaultSearch = {
-  placeholder: string;
-  results: OutputObject[] | void | undefined;
-  searchTerm: string;
-};
-
-interface Grade {
+export type GradeType = {
   difficulty: string;
   band: string;
-}
-type GradeOptions =
+};
+type GradeOptionTypes =
   | "Grade"
   | "none"
   | "M, D, VD, HVD, S, 1, 2, 2a, 2b, 2c, 3, 3a, 3b, 3c, 4a, 4b, 4c, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, n1, n2, n3, n4, f1, f2, f2+, f3, f3+, VB, V0-, V0, I, II, WI-1, WI-2"
   | "HS, MVS, VS, HVS, 5a, 5b, 5c, 6a, 6a+, 5.7, 5.8, 5.9, 5.10a, 5.10b, 5.10c, n5-, n5, n5+, f4, f4+, V0+, V1, V2, III, IV, WI-3, WI-4"
   | "E1, E2, E3, 6b, 6b+, 6c, 6c+, 7a, 5.10d, 5.11a, 5.11b, 5.11c, 5.11d, n6-, n6, n6+, f5, f5+, V3, V4, V5, V6, f6A, f6A+, V, VI, WI-5"
   | "E4, E5, E6, E7, E8, E9, E10, E11, E12, 7a+, 7b, 7b+, 7c, 7c+, 8a, 8a+, 8b, 8b+, 8c, 8c+, 9a, 9a+, 9b, 9b+, 9c, 5.12a, 5.12b, 5.12c, 5.12d, 5.13a, 5.13b, 5.13c, 5.13d, 5.14a, n7-, n7, n7+, n8-, n, n8+, f6B, f6B+, f6C, f6C+, f7A, f7A+, f7B, f7B+, f7C, f7C+, f8A, V7, V8, V9, V10, V11, V12, V13, V14, V15, VII, VIII, IX, X, WI-6, WI-7";
-type Grades = {
-  [key in GradeOptions]: Grade;
+export type GradeTypes = {
+  [key in GradeOptionTypes]: GradeType;
 };
 
-type LogOptions = "cragName" | "date" | "grade" | "partners" | "style";
-type IconOptions = LogOptions | "chevron" | "comment";
+export type LogbookType = "cragName" | "date" | "grade" | "partners" | "style";
+export type LogbookIconsType = LogbookType | "chevron" | "comment";
 
-type Breakpoints = "XXsmall" | "Xsmall" | "small" | "tablet" | "large" | "Xlarge" | "massive";
-
-export {
-  MonthOptions,
-  DateOptions,
-  Date,
-  OutputObject,
-  DefaultSearch,
-  Grade,
-  Grades,
-  LogOptions,
-  IconOptions,
-  Breakpoints,
+export type SearchType = {
+  placeholder: string;
+  results: LogType[] | void | undefined;
+  searchTerm: string;
 };
+
+export type SettingsType = "date" | "discipline" | "grade" | "partners" | "style";
+export interface SettingsInt {
+  date: { cumulative: DefaultDates };
+  discipline: { cumulative: DefaultDisciplines };
+  grade: { cumulative: DefaultGrades };
+  partners: { cumulative: DefaultPartners };
+  style: { cumulative: DefaultStyles };
+  type: SettingsType;
+}


### PR DESCRIPTION
- Highlight the covered segments of the pie chart and key when hovered
- Clean up type definitions, and follow better naming conventions
- Tidy up the section dropdown, used for stats filtering