### PR TITLE
fix chrome and safari bug: missing stats chart

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -14,7 +14,10 @@ const Root = styled.div`
   font-family: ${fonts.main};
   font-size: ${fontSize.small};
   line-height: 1.4;
-  min-height: 100vh;
+  height: calc(100vh - 84px);
+  @media only screen and (min-width: ${breakpoint.small}) {
+    height: calc(100vh - 114px);
+  }
 `;
 
 const Header = styled.header`
@@ -61,10 +64,7 @@ const DailyMessage = styled.p`
 
 const ViewContainer = styled.div`
   max-width: 60rem;
-  margin: 0 auto;
-  padding-top: 1rem;
-  box-sizing: border-box;
-  overflow: hidden;
+  margin: 1rem auto 0;
 `;
 
 const ViewPanel = styled.div<{ translatePercent: number }>`
@@ -78,14 +78,15 @@ const ViewPanel = styled.div<{ translatePercent: number }>`
 type Views = {
   s: string;
   l: string;
-}
+};
 const views: Views = {
   s: "Stats",
-  l: "Logbook"
+  l: "Logbook",
 };
 
 const App: FC = (): JSX.Element => {
   const [activeView, setActiveView] = useState<string>(views.s);
+  const [hideView, setHideView] = useState<string | null>(views.l);
   const [logs, setLogs] = useState<LogType[]>(allLogs);
   const [message, setMessage] = useState<string | null>(null);
 
@@ -106,6 +107,14 @@ const App: FC = (): JSX.Element => {
     }
   }, [message, activeView]);
 
+  // hide panels when the transition ends
+  useEffect(() => {
+    setTimeout(() => {
+      const { l, s } = views;
+      setHideView(activeView === s ? l : s);
+    }, 1000);
+  }, [activeView]);
+
   return (
     <Root>
       {message && <DailyMessage>{message}</DailyMessage>}
@@ -113,7 +122,10 @@ const App: FC = (): JSX.Element => {
         {Object.values(views).map(view => (
           <ViewButton
             key={view}
-            onClick={() => setActiveView(view)}
+            onClick={() => {
+              setActiveView(view);
+              setHideView(null);
+            }}
             isActive={activeView === view}
             aria-label={`${view} View`}
           >
@@ -121,11 +133,10 @@ const App: FC = (): JSX.Element => {
           </ViewButton>
         ))}
       </Header>
-
       <ViewContainer>
         <ViewPanel translatePercent={activeView === views.l ? -50 : 0}>
-          <Stats logs={logs} handleSingleDay={handleSingleDay} />
-          <Logbook logs={logs} isActive={activeView === views.l}/>
+          <Stats logs={logs} handleSingleDay={handleSingleDay} isHidden={hideView === views.s} />
+          <Logbook logs={logs} isHidden={hideView === views.l} />
         </ViewPanel>
       </ViewContainer>
     </Root>

--- a/src/components/logbook/Logbook.tsx
+++ b/src/components/logbook/Logbook.tsx
@@ -9,9 +9,9 @@ import PageNav from "./PageNav";
 import Results from "./Results";
 import SingleLog from "../singleLog/SingleLog";
 
-const LogContainer = styled.div<{isActive: boolean}>`
+const LogContainer = styled.div<{isHidden: boolean}>`
   width: 50%;
-  ${({ isActive }) => !isActive && `height: 0`};
+  ${({ isHidden }) => isHidden && `height: 0; opacity: 0`};
 `;
 
 const defaultSearch: SearchType = {
@@ -21,10 +21,10 @@ const defaultSearch: SearchType = {
 };
 
 type Props = {
-  isActive: boolean;
+  isHidden: boolean;
   logs: LogType[];
 }
-const Logbook: FC<Props> = ({ isActive, logs }): JSX.Element => {
+const Logbook: FC<Props> = ({ isHidden, logs }): JSX.Element => {
   const [search, setSearch] = useState<SearchType | undefined>(defaultSearch);
   const [page, setPage] = useState<{ low: number; high: number }>({ low: 0, high: 50 });
   const [singleLog, setSingleLog] = useState<LogType | undefined>(undefined);
@@ -59,7 +59,7 @@ const Logbook: FC<Props> = ({ isActive, logs }): JSX.Element => {
   };
 
   return (
-    <LogContainer isActive={isActive}>
+    <LogContainer isHidden={isHidden}>
       <div>
         {!singleLog && (
           <Fragment>

--- a/src/components/stats/Legend.tsx
+++ b/src/components/stats/Legend.tsx
@@ -129,7 +129,7 @@ const Legend: FC<Props> = ({ chartdata, settings }): JSX.Element => {
         <Items>
           {chartdata.map((d, index: number) => (
             <Item
-              aria-label={d.data.keyLabel[0]}
+              aria-labelledby="key item"
               key={index}
               opacity={hovered && activeArcIndex !== index ? 0.5 : 1}
               onMouseOver={() => setActiveItem(index)}

--- a/src/components/stats/PieChart.tsx
+++ b/src/components/stats/PieChart.tsx
@@ -19,6 +19,7 @@ const ChartContainer = styled.div`
     margin: 0;
     margin-left: auto;
     padding-right: 1rem;
+    width: 100%;
   }
 `;
 
@@ -39,9 +40,10 @@ const DismissObject = styled.foreignObject`
   transform: translate(-200px, -200px);
 `;
 
-const HoverTooltip = styled.foreignObject`
+const HoverTooltip = styled.foreignObject<{positioning: number[] | undefined}>`
   pointer-events: none;
-  padding: 0 0.25rem 0.25rem 0;
+  transform: scale(1.125)
+    ${({ positioning }) => positioning && `translate(${positioning[0]}px, ${positioning[1]}px)`};
   div {
     width: auto;
     z-index: 1;
@@ -86,18 +88,20 @@ const PieChart: FC<Props> = ({
     .innerRadius(innerRadius)
     .outerRadius(outerRadius);
 
-  const getToolPos = (data: ChartType, arcFunc, radius) => {
+  const getToolPos = (data: ChartType, arcFunc, radius): number[] | undefined => {
     if (typeof data !== "object" || !arcFunc.centroid) {
-      return "translate(0, 0)";
+      return;
     }
     const [a, b] = arcFunc.centroid(data);
     if (a && b) {
-      return `translate(${a - radius / 4}, ${b - radius / 4})`;
+      const x = a - radius / 4;
+      const y = b - radius / 4;
+      return [x, y];
     }
-    return "translate(0, 0)";
+    return;
   };
 
-  const showTooltip = chartdata[activeArcIndex];
+  const showTooltip = activeArcIndex && chartdata[activeArcIndex];
 
   return (
     <ChartContainer>
@@ -118,7 +122,7 @@ const PieChart: FC<Props> = ({
         ))}
         {showTooltip && (
           <HoverTooltip
-            transform={getToolPos(showTooltip, createArc, outerRadius)}
+            positioning={getToolPos(showTooltip, createArc, outerRadius)}
             width={150}
             height={40}
           >

--- a/src/components/stats/Stats.tsx
+++ b/src/components/stats/Stats.tsx
@@ -13,8 +13,9 @@ import PieChart from "./PieChart";
 import Legend from "./Legend";
 import { breakpoint } from "../common/styleVariables";
 
-const StatContainer = styled.div`
+const StatContainer = styled.div<{isHidden: boolean}>`
   width: 50%;
+  ${({ isHidden }) => isHidden && `height: 0; opacity: 0`};
 `;
 
 const BodySection = styled.section`
@@ -29,6 +30,7 @@ const BodySection = styled.section`
 // Make this easier to reason about, bit by bit
 // - draw a diagram / note information flows
 // - can the original shape of the data be changed to help?
+// ^ less data = less processing
 // - cut down on legacy / old stuff
 
 // AFTER:
@@ -233,9 +235,10 @@ const getChartData = (settingState: SettingsInt, logs: LogType[]) => {
 
 type Props = {
   handleSingleDay: (logs: LogType[], filter: FilterType) => void;
+  isHidden: boolean;
   logs: LogType[];
 };
-const Stats: FC<Props> = ({ handleSingleDay, logs }) => {
+const Stats: FC<Props> = ({ handleSingleDay, isHidden, logs }) => {
   const [settings, setSettings] = useState<SettingsInt>(defaultSettings);
 
   // put this in StatsHeader perhaps:
@@ -338,7 +341,7 @@ const Stats: FC<Props> = ({ handleSingleDay, logs }) => {
 
   return (
     <StatsContextProvider>
-      <StatContainer>
+      <StatContainer isHidden={isHidden}>
         <StatsHeader logs={logs} setDropdown={setDropdown} type={type} />
         <BodySection>
           {chartdata && type === "date" ? (

--- a/src/components/stats/StatsContext.tsx
+++ b/src/components/stats/StatsContext.tsx
@@ -1,24 +1,23 @@
-import React, { FC, createContext, useReducer } from "react";
-
+import React, { Dispatch, Reducer, FC, createContext, useReducer } from "react";
 interface ContextProps {
-  state: any;
-  dispatch: ({ type }: { type: string }) => void;
+  state: StateType;
+  dispatch: Dispatch<ActionType>;
 }
-let StatsContext = createContext<{}>({} as ContextProps);
+export const StatsContext = createContext({} as ContextProps);
 
-type InitialStateType = {
-  activeArcIndex: undefined | number;
+type StateType = {
+  activeArcIndex: number | undefined;
 };
-let initialState: InitialStateType = {
-  activeArcIndex: undefined,
-};
-
 type ActionType = {
   payload: undefined | number;
   type: string;
 };
 
-let reducer = (state: InitialStateType, action: ActionType) => {
+const initialState: StateType = {
+  activeArcIndex: undefined,
+};
+
+const reducer: Reducer<StateType, ActionType> = (state, action) => {
   switch (action.type) {
     case "activeArcIndex":
       return { ...state, activeArcIndex: action.payload };
@@ -29,14 +28,10 @@ let reducer = (state: InitialStateType, action: ActionType) => {
 };
 
 type Props = {
-  init?: InitialStateType;
+  init?: StateType;
 };
-const StatsContextProvider: FC<Props> = ({ init = initialState, children }) => {
+export const StatsContextProvider: FC<Props> = ({ init = initialState, children }) => {
   const [state, dispatch] = useReducer(reducer, init);
   const value = { state, dispatch };
   return <StatsContext.Provider value={value}>{children}</StatsContext.Provider>;
 };
-
-const StatsContextConsumer = StatsContext.Consumer;
-
-export { StatsContext, StatsContextProvider, StatsContextConsumer };


### PR DESCRIPTION
- Noticed the stats chart was missing on Chrome and Safari. Fixed this - the container required full width
- Some positioning for the stats chart key on mobile
- Fix TypeScript context errors
- Better handling of slide transition and Pie Chart tooltip cutoffs.