### PR TITLE
retain search results when clicking into a single logbook, align search results

### DIFF
--- a/src/components/logbook/Logbook.tsx
+++ b/src/components/logbook/Logbook.tsx
@@ -3,15 +3,15 @@ import styled from "styled-components";
 
 import { LogType, SearchType } from "../../utils/types";
 
-import Search from "./Search";
-import SearchReset from "./SearchReset";
+import { Search } from "./Search";
+import { SearchReset } from "./SearchReset";
 import PageNav from "./PageNav";
 import Results from "./Results";
 import SingleLog from "../singleLog/SingleLog";
 
-const LogContainer = styled.div<{isHidden: boolean}>`
+const LogContainer = styled.div<{ isHidden: boolean }>`
   width: 50%;
-  ${({ isHidden }) => isHidden && `height: 0; opacity: 0`};
+  ${({ isHidden }) => isHidden && "height: 0; opacity: 0"};
 `;
 
 const defaultSearch: SearchType = {
@@ -20,11 +20,11 @@ const defaultSearch: SearchType = {
   results: undefined,
 };
 
-type Props = {
+type LogbookProps = {
   isHidden: boolean;
   logs: LogType[];
-}
-const Logbook: FC<Props> = ({ isHidden, logs }): JSX.Element => {
+};
+const Logbook: FC<LogbookProps> = ({ isHidden, logs }): JSX.Element => {
   const [search, setSearch] = useState<SearchType | undefined>(defaultSearch);
   const [page, setPage] = useState<{ low: number; high: number }>({ low: 0, high: 50 });
   const [singleLog, setSingleLog] = useState<LogType | undefined>(undefined);
@@ -66,15 +66,15 @@ const Logbook: FC<Props> = ({ isHidden, logs }): JSX.Element => {
             <Search handleSearch={handleSearch} handleSingleView={handleSingleView} {...search} />
             <PageNav {...page} logs={logs} handlePageChange={handlePageChange} />
             <Results {...page} logs={logs} handleSingleView={handleSingleView} />
+            <SearchReset
+              onClose={() => {
+                setSearch(defaultSearch);
+              }}
+            />
           </Fragment>
         )}
         {singleLog && <SingleLog {...singleLog} handleSingleView={handleSingleView} />}
       </div>
-      <SearchReset
-        onClose={() => {
-          setSearch(defaultSearch);
-        }}
-      />
     </LogContainer>
   );
 };

--- a/src/components/logbook/Results.tsx
+++ b/src/components/logbook/Results.tsx
@@ -79,6 +79,11 @@ const Date = styled.span`
   margin-left: auto;
   display: flex;
   align-items: center;
+  @media only screen and (min-width: ${breakpoint.tablet}) {
+    flex: 2.5;
+    justify-content: space-between;
+    margin-left: 2rem;
+  }
 `;
 
 const Small = styled.span`

--- a/src/components/logbook/Search.tsx
+++ b/src/components/logbook/Search.tsx
@@ -1,10 +1,9 @@
 import React, { FC } from "react";
 import styled from "styled-components";
 
+import { SearchResults } from "./SearchResults";
 import { SearchType } from "../../utils/types";
-import { colors, fonts, boxShadow, breakpoint } from "../common/styleVariables";
-import { searchResultText } from "../common/Typography";
-import { buttonBase } from "../common/Buttons";
+import { colors, fonts, breakpoint } from "../common/styleVariables";
 
 const SearchContainer = styled.div`
   position: relative;
@@ -66,85 +65,11 @@ const SearchBar = styled.input`
   }
 `;
 
-const Results = styled.ul`
-  position: absolute;
-  top: 42px;
-  @media only screen and (min-width: ${breakpoint.Xsmall}) {
-    top: 47px;
-  }
-  @media only screen and (min-width: ${breakpoint.small}) {
-    top: 71px;
-  }
-  margin-top: 1rem;
-  left: 0.5rem;
-  z-index: 2;
-  width: calc(100% - 1rem);
-  max-height: 65vh;
-  overflow-y: scroll;
-  box-shadow: ${boxShadow.top};
-`;
-
-const ResultButton = styled.button`
-  ${buttonBase};
-  width: 100%;
-  display: flex;
-  align-items: center;
-  font-weight: 500;
-  text-align: left;
-  font-size: 1rem;
-  padding: 0.5rem;
-  @media only screen and (min-width: ${breakpoint.Xsmall}) {
-    padding: 0.5rem 1rem;
-    font-size: 1.25rem;
-  }
-  @media only screen and (min-width: ${breakpoint.tablet}) {
-    font-size: 1.125rem;
-  }
-  background-color: ${colors.lightGrey};
-  border: 0.125rem solid transparent;
-  border-bottom-color: ${colors.midGrey};
-  &:hover {
-    background-color: ${colors.lightBlue};
-    border-color: ${colors.midBlue};
-  }
-`;
-
-const Climb = styled.span`
-  ${searchResultText};
-  flex: 3;
-`;
-
-const Crag = styled.span`
-  display: none;
-  @media only screen and (min-width: ${breakpoint.tablet}) {
-    display: flex;
-    ${searchResultText};
-    font-weight: 400;
-    flex: 2;
-  }
-`;
-
-const DateSmall = styled.span`
-  margin-left: auto;
-  font-weight: 600;
-  @media only screen and (min-width: ${breakpoint.tablet}) {
-    display: none;
-  }
-`;
-const DateLarge = styled.span`
-  display: none;
-  @media only screen and (min-width: ${breakpoint.tablet}) {
-    display: flex;
-    margin-left: auto;
-    font-weight: 600;
-  }
-`;
-
-type Props = Partial<SearchType> & {
+type SearchProps = Partial<SearchType> & {
   handleSearch: (value: string) => void;
   handleSingleView: (index: string | null) => void;
 };
-const Search: FC<Props> = ({
+export const Search: FC<SearchProps> = ({
   handleSearch,
   handleSingleView,
   placeholder,
@@ -162,30 +87,7 @@ const Search: FC<Props> = ({
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleSearch(e.currentTarget.value)}
       />
 
-      {results && (
-        <Results>
-          {results.map(({ climbName, cragName, date, key }) => {
-            // TODO: Simplify
-            const { day, dayLong, monthInt, monthLong, year, yearInt } = date;
-            const dateLarge = `${dayLong} ${monthLong} ${year}`;
-            return (
-              <li key={key}>
-                <ResultButton
-                  aria-label={`Go to log for: ${climbName} on ${dateLarge}`}
-                  onClick={() => handleSingleView(key)}
-                >
-                  <Climb>{climbName}</Climb>
-                  <Crag>{cragName}</Crag>
-                  <DateSmall>{`${day}/${monthInt}/${yearInt}`}</DateSmall>
-                  <DateLarge>{`${dateLarge}`}</DateLarge>
-                </ResultButton>
-              </li>
-            );
-          })}
-        </Results>
-      )}
+      {results && <SearchResults handleSingleView={handleSingleView} results={results} />}
     </SearchContainer>
   );
 };
-
-export default Search;

--- a/src/components/logbook/SearchReset.tsx
+++ b/src/components/logbook/SearchReset.tsx
@@ -4,7 +4,7 @@ interface Props {
   onClose: () => void;
 }
 
-const SearchReset: FC<Props> = ({ onClose }) => {
+export const SearchReset: FC<Props> = ({ onClose }) => {
   const ref = useRef<HTMLDivElement>(null);
   const escapeListener = useCallback(
     e => {
@@ -16,7 +16,8 @@ const SearchReset: FC<Props> = ({ onClose }) => {
   );
   const clickListener = useCallback(
     e => {
-      if (ref.current && !ref.current.contains(e.target)) {
+      // Reset if no value is in the search bar with !e.target.value
+      if (ref.current && !ref.current.contains(e.target) && !e.target.value) {
         onClose?.();
       }
     },
@@ -32,7 +33,5 @@ const SearchReset: FC<Props> = ({ onClose }) => {
       document.removeEventListener("keyup", escapeListener);
     };
   }, [clickListener, escapeListener]);
-  return <div ref={ref}/>;
+  return <div ref={ref} />;
 };
-
-export default SearchReset;

--- a/src/components/logbook/SearchResults.tsx
+++ b/src/components/logbook/SearchResults.tsx
@@ -1,0 +1,113 @@
+import React, { FC } from "react";
+import styled from "styled-components";
+
+import { LogType } from "../../utils/types";
+
+import { searchResultText } from "../common/Typography";
+import { buttonBase } from "../common/Buttons";
+import { colors, boxShadow, breakpoint } from "../common/styleVariables";
+
+const Results = styled.ul`
+  position: absolute;
+  top: 42px;
+  @media only screen and (min-width: ${breakpoint.Xsmall}) {
+    top: 47px;
+  }
+  @media only screen and (min-width: ${breakpoint.small}) {
+    top: 71px;
+  }
+  margin-top: 1rem;
+  left: 0.5rem;
+  z-index: 2;
+  width: calc(100% - 1rem);
+  max-height: 65vh;
+  overflow-y: scroll;
+  box-shadow: ${boxShadow.top};
+`;
+
+const ResultButton = styled.button`
+  ${buttonBase};
+  width: 100%;
+  display: flex;
+  align-items: center;
+  font-weight: 500;
+  text-align: left;
+  font-size: 1rem;
+  padding: 0.5rem;
+  @media only screen and (min-width: ${breakpoint.Xsmall}) {
+    padding: 0.5rem 1rem;
+    font-size: 1.25rem;
+  }
+  @media only screen and (min-width: ${breakpoint.tablet}) {
+    font-size: 1.125rem;
+  }
+  background-color: ${colors.lightGrey};
+  border: 0.125rem solid transparent;
+  border-bottom-color: ${colors.midGrey};
+  &:hover {
+    background-color: ${colors.lightBlue};
+    border-color: ${colors.midBlue};
+  }
+`;
+
+const Climb = styled.span`
+  ${searchResultText};
+  flex: 3;
+  @media only screen and (min-width: ${breakpoint.tablet}) {
+    max-width: 40%;
+  }
+`;
+
+const Crag = styled.span`
+  display: none;
+  @media only screen and (min-width: ${breakpoint.tablet}) {
+    display: flex;
+    ${searchResultText};
+    font-weight: 400;
+    flex: 2;
+  }
+`;
+
+const DateSmall = styled.span`
+  margin-left: auto;
+  font-weight: 600;
+  @media only screen and (min-width: ${breakpoint.tablet}) {
+    display: none;
+  }
+`;
+const DateLarge = styled.span`
+  display: none;
+  @media only screen and (min-width: ${breakpoint.tablet}) {
+    display: flex;
+    margin-left: auto;
+    font-weight: 600;
+  }
+`;
+
+interface SearchResultsProps {
+  handleSingleView: (index: string | null) => void;
+  results: LogType[];
+}
+
+export const SearchResults: FC<SearchResultsProps> = ({ results, handleSingleView }) => (
+  <Results>
+    {results.map(({ climbName, cragName, date, key }) => {
+      // TODO: Simplify / use new date object
+      const { day, dayLong, monthInt, monthLong, year, yearInt } = date;
+      const dateLarge = `${dayLong} ${monthLong} ${year}`;
+      return (
+        <li key={key}>
+          <ResultButton
+            aria-label={`Go to log for: ${climbName} on ${dateLarge}`}
+            onClick={() => handleSingleView(key)}
+          >
+            <Climb>{climbName}</Climb>
+            <Crag>{cragName}</Crag>
+            <DateSmall>{`${day}/${monthInt}/${yearInt}`}</DateSmall>
+            <DateLarge>{`${dateLarge}`}</DateLarge>
+          </ResultButton>
+        </li>
+      );
+    })}
+  </Results>
+);

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -158,7 +158,7 @@ export type SearchType = {
 };
 
 export type SettingsType = "date" | "discipline" | "grade" | "partners" | "style";
-type DefaultDates = "Year" | "Month";
+// type DefaultDates = "Year" | "Month";
 type DefaultDisciplines = "Bouldering" | "Ice" | "Mixed" | "Sport" | "Trad";
 type DefaultGrades = "Low" | "High"; // order low to high
 type DefaultPartners = string | undefined;


### PR DESCRIPTION
- Addresses #43 and #66 
- Retain the last search results when clicking into a single logbook entry, then back out to logbook view
- Aligns search results list, and logbook items list
- Splits Search results list into a separate component
- Uses more named than default exports